### PR TITLE
feat(#61) : Manage back navigation to buildings list

### DIFF
--- a/src/pages/building-main/building-main.html
+++ b/src/pages/building-main/building-main.html
@@ -20,9 +20,9 @@
       <ion-grid>
         <ion-row no-padding class="other-data">
           <ion-col no-padding class="column">
-            <button ion-button icon-left small full color="light" menuClose (click)="goBackToInspection()">
+            <button ion-button icon-left small full color="light" menuClose (click)="goBackToBuildingList()">
               <ion-icon name="undo"></ion-icon>
-              Retourner à l'inspection
+              Retourner à la liste des bâtiments
             </button>
           </ion-col>
         </ion-row>

--- a/src/pages/building-main/building-main.ts
+++ b/src/pages/building-main/building-main.ts
@@ -50,7 +50,7 @@ export class BuildingMainPage {
   }
 
   public goBackToBuildingList() {
-    this.app.getRootNav().popTo('InterventionBuildingsPage');
+      this.navCtrl.setRoot('InterventionBuildingsPage');
   }
 
   public openPage(page) : void {

--- a/src/pages/building-main/building-main.ts
+++ b/src/pages/building-main/building-main.ts
@@ -2,6 +2,7 @@ import {Component, ViewChild} from '@angular/core';
 import {App, IonicPage, MenuController, NavController, NavParams} from 'ionic-angular';
 import {InspectionControllerProvider} from '../../providers/inspection-controller/inspection-controller';
 import {MenuItem} from '../../interfaces/menu-item.interface';
+import {InterventionBuildingsPage} from "../intervention-buildings/intervention-buildings";
 
 @IonicPage()
 @Component({
@@ -48,15 +49,9 @@ export class BuildingMainPage {
     this.menuCtrl.enable(true, 'buildingMenu');
   }
 
-  public async goBackToInspection() {
-    await this.app.getRootNav().popToRoot();
-    //await this.app.getRootNav().setRoot('InterventionHomePage',  {id: this.controller.idInspection});
-    await this.app.getRootNav().push('InterventionHomePage', {id: this.controller.idInspection, page: 'InterventionBuildingsPage'});
+  public goBackToBuildingList() {
+    this.app.getRootNav().popTo('InterventionBuildingsPage');
   }
-
-  /*public async goBackToInspectionList() {
-    await this.app.getRootNav().popToRoot();
-  }*/
 
   public openPage(page) : void {
     this.childNavCtrl.setRoot(page, this.getParams());

--- a/src/pages/intervention-buildings/intervention-buildings.ts
+++ b/src/pages/intervention-buildings/intervention-buildings.ts
@@ -1,16 +1,10 @@
 import { Component } from '@angular/core';
-import {App, IonicPage, NavController, NavParams, ViewController} from 'ionic-angular';
+import {App, IonicPage, MenuController, NavController, NavParams, ViewController} from 'ionic-angular';
 import {AuthenticationService} from '../../providers/Base/authentification.service';
 import {InspectionBuildingForList} from '../../models/inspection-building-for-list';
 import {InspectionControllerProvider} from '../../providers/inspection-controller/inspection-controller';
 import {InspectionDetail} from '../../models/inspection-detail';
 
-/**
- * Generated class for the InterventionBuildingsPage page.
- *
- * See http://ionicframework.com/docs/components/#navigation for more info
- * on Ionic pages and navigation.
- */
 @IonicPage()
 @Component({
   selector: 'page-intervention-buildings',
@@ -30,7 +24,8 @@ export class InterventionBuildingsPage {
               private appCtrl: App,
               public navParams: NavParams,
               private controller: InspectionControllerProvider,
-              private authService: AuthenticationService) {
+              private authService: AuthenticationService,
+              private menuCtrl: MenuController) {
     this.controller.loadBuildingList();
   }
 
@@ -38,6 +33,8 @@ export class InterventionBuildingsPage {
   }
 
   async ionViewCanEnter() {
+      this.menuCtrl.enable(true, 'inspectionMenu');
+      this.menuCtrl.enable(false, 'buildingMenu');
     let isLoggedIn = await this.authService.isStillLoggedIn();
     if (!isLoggedIn)
       this.redirectToLoginPage();

--- a/src/pages/intervention-home/intervention-home.ts
+++ b/src/pages/intervention-home/intervention-home.ts
@@ -18,8 +18,7 @@ export class InterventionHomePage {
   constructor(public navCtrl: NavController, public navParams: NavParams, public menuCtrl: MenuController, private controller: InspectionControllerProvider) {
     controller.setIdInterventionForm(this.navParams.data['id']);
     console.log('paaage', this.navParams.data['page']);
-    /*if (this.navParams.data['page'] != null)
-      this.rootPage = this.navParams.data['page'];*/
+
     this.menuItems = [
       { title: 'Infos générales', page:'InterventionGeneralPage', icon:'information-circle' },
       { title: 'Bâtiments', page:'InterventionBuildingsPage', icon:'home' },


### PR DESCRIPTION
Change the back navigation from the detailed building pages to go to buildings list on the back action into the menu.
Change the name of the button for "Retourner à la liste des bâtiments"
