### PR TITLE
feat(#102): Asking for camera permissions so app won't crash

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -98,4 +98,10 @@
     <plugin name="cordova-plugin-whitelist" spec="^1.3.3" />
     <plugin name="ionic-plugin-keyboard" spec="^2.2.1" />
     <plugin name="cordova-plugin-compat" spec="^1.1.0" />
+    <edit-config file="*-Info.plist" mode="merge" target="NSCameraUsageDescription">
+        <string>need camera access to take pictures</string>
+    </edit-config>
+    <edit-config file="*-Info.plist" mode="merge" target="NSPhotoLibraryUsageDescription">
+        <string>need photo library access to get pictures from there</string>
+    </edit-config>
 </widget>


### PR DESCRIPTION
Pour régler le problème de l'application qui crash.
(Voir https://github.com/apache/cordova-plugin-camera, section 'ios Quirks' pour plus de détails)