### PR TITLE
#113 sketch zoom pan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5090,9 +5090,9 @@
       }
     },
     "lib-sketch-tool": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/lib-sketch-tool/-/lib-sketch-tool-1.3.7.tgz",
-      "integrity": "sha512-LNqZPr22djlt7lBiO8cPuZqiGfdJHI6v+HciNcpIXB5e8hxvIMEMuTecbjZ8Z8Kin3iOpEJxto+yG+gkJl96NQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/lib-sketch-tool/-/lib-sketch-tool-1.4.0.tgz",
+      "integrity": "sha512-i76ngYcG7TXPmum/XAOaMulaaaafQwzD9hen+YicK4LrjbO6W6CNqYaRn8dcLtwvUA8tKkXK4AuZgnH+oKZzow==",
       "requires": {
         "tslib": "^1.7.1"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ionic-plugin-keyboard": "^2.2.1",
     "ionicons": "3.0.0",
     "ios": "0.0.1",
-    "lib-sketch-tool": "^1.4.0",
+    "lib-sketch-tool": "^1.5.0",
     "material-design-icons": "3.0.1",
     "ol": "^5.1.3",
     "openlayers": "^4.6.5",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ionic-plugin-keyboard": "^2.2.1",
     "ionicons": "3.0.0",
     "ios": "0.0.1",
-    "lib-sketch-tool": "^1.3.7",
+    "lib-sketch-tool": "^1.4.0",
     "material-design-icons": "3.0.1",
     "ol": "^5.1.3",
     "openlayers": "^4.6.5",

--- a/src/components/picture-viewer/picture-viewer.ts
+++ b/src/components/picture-viewer/picture-viewer.ts
@@ -148,7 +148,7 @@ export class PictureViewerComponent implements ControlValueAccessor, OnDestroy {
   private getPicture(options: CameraOptions) {
     try {
       this.camera.getPicture(options).then((imageData) => {
-        this.value.dataUri = imageData;
+        this.value = {id: this.value.id, picture: imageData, dataUri: imageData, sketchJson: null};
       }, (err) => {
         alert(err);
       });

--- a/src/pages/building-child-picture-edition/building-child-picture-edition.ts
+++ b/src/pages/building-child-picture-edition/building-child-picture-edition.ts
@@ -2,6 +2,7 @@ import {Component, Input} from '@angular/core';
 import {IonicPage, NavController, NavParams, ViewController} from 'ionic-angular';
 import {BuildingChildPictureRepositoryProvider} from '../../interfaces/building-child-picture-repository-provider';
 import {InspectionBuildingChildPictureForWeb} from '../../models/inspection-building-child-picture-for-web';
+import { fabric } from 'fabric';
 
 /**
  * Generated class for the ImageEditionPage page.
@@ -40,8 +41,11 @@ export class BuildingChildPictureEditionPage {
 
   async onOkay() {
     if (this.canvas) {
-      this.canvas.renderAll();
        let json = JSON.stringify(this.canvas.toJSON());
+
+       this.canvas.zoomToPoint(new fabric.Point(0, 0), 1);
+       this.canvas.absolutePan(new fabric.Point(0, 0));
+
        let imageUri = this.canvas.toDataURL();
       if (imageUri.indexOf(';base64,') > 0)
         imageUri = imageUri.substr(imageUri.indexOf(';base64,') + 8);

--- a/src/pages/intervention-implantation-plan-sketch/intervention-implantation-plan-sketch.ts
+++ b/src/pages/intervention-implantation-plan-sketch/intervention-implantation-plan-sketch.ts
@@ -2,7 +2,8 @@ import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams, ViewController } from 'ionic-angular';
 import { PictureRepositoryProvider } from './../../providers/repositories/picture-repository';
 import { PictureData } from './../../models/picture-data';
-import {InspectionControllerProvider} from '../../providers/inspection-controller/inspection-controller';
+import { InspectionControllerProvider } from '../../providers/inspection-controller/inspection-controller';
+import { Gesture } from 'ionic-angular/gestures/gesture';
 import { fabric } from 'fabric';
 
 @IonicPage()
@@ -45,9 +46,10 @@ export class InterventionImplantationPlanSketchPage {
 
   public async onOkay() {
     if (this.canvas) {
-      this.canvas.renderAll();
-
       let json = JSON.stringify(this.canvas.toJSON());
+
+      this.canvas.zoomToPoint(new fabric.Point(0, 0), 1);
+      this.canvas.absolutePan(new fabric.Point(0, 0));
 
       let imageUri = this.canvas.toDataURL();
       if (imageUri.indexOf(';base64,') > 0)

--- a/src/pages/intervention-implantation-plan/intervention-implantation-plan.ts
+++ b/src/pages/intervention-implantation-plan/intervention-implantation-plan.ts
@@ -44,14 +44,6 @@ export class InterventionImplantationPlanPage implements OnDestroy {
       this.controller.loadInterventionFormPicture();
  }
 
-  ionViewDidEnter() {
-    this.menu.swipeEnable(false);
-  }
-
-  ionViewWillLeave() {
-    this.menu.swipeEnable(true);
-  }
-
   private createForm() {
     this.form = this.fb.group({id: [''], picture: [''], dataUri: [''], sketchJson: ['']});
   }


### PR DESCRIPTION
Permet le zoom et le déplacement dans une image lorsque zoomé.

Le pan se fait présentement en utilisant 3 doigts : 1 seul doigt interfère avec les fonctionalités du canevas (sélection, déplacement d'object, scale ...) et 2 avec le pinch. Un autre option pourrait être d'activer le pan avec un icone ou quelque chose du même genre pour permettre l'utilisation du pan avec une seule touche.

(Ne pas faire  attention aux icônes sur cette branche, ils ne sont pas affichés, mais c'est déjà réparé sur la branche 115.)