### PR TITLE
feat(#152) Adapt site plan sketchtools to new picture saving format

### DIFF
--- a/src/components/picture-viewer/picture-viewer.ts
+++ b/src/components/picture-viewer/picture-viewer.ts
@@ -161,7 +161,7 @@ export class PictureViewerComponent implements ControlValueAccessor, OnDestroy {
   }
 
   public onEditPhoto(){
-    const picture = {id: this.value.id, picture: this.imageUrl, dataUri: this.imageUrl, sketchJson: this.imageJson}
+    const picture = {id: this.value.id, picture: this.imageData.dataUri, dataUri: this.imageData.dataUri, sketchJson: this.imageJson}
     let modal = this.modalCtrl.create('InterventionImplantationPlanSketchPage', { picture: picture, repo: this.repo });
     modal.present();
   }

--- a/src/components/search-box/search-box.ts
+++ b/src/components/search-box/search-box.ts
@@ -25,7 +25,7 @@ export class SearchBoxComponent implements ControlValueAccessor, OnDestroy {
     @Input() description: string;
     @Input() showDescription: boolean = true;
     @Input() hasValidationError: boolean;
-    @Input() isDisabled: boolean = true;
+    @Input() isDisabled: boolean = false;
 
     constructor(private modalCtrl: ModalController) {
     }

--- a/src/pages/building-child-picture-edition/building-child-picture-edition.ts
+++ b/src/pages/building-child-picture-edition/building-child-picture-edition.ts
@@ -17,8 +17,8 @@ import { fabric } from 'fabric';
   templateUrl: 'building-child-picture-edition.html'
 })
 export class BuildingChildPictureEditionPage {
-  picture: InspectionBuildingChildPictureForWeb;
-  repo: BuildingChildPictureRepositoryProvider;
+  public picture: InspectionBuildingChildPictureForWeb;
+  public repo: BuildingChildPictureRepositoryProvider;
 
   private canvas;
 
@@ -35,11 +35,11 @@ export class BuildingChildPictureEditionPage {
     return this.picture.sketchJson;
   }
 
-  onCanvasChange($event) {
+  public onCanvasChange($event) {
     this.canvas = $event;
   }
 
-  async onOkay() {
+  public async onOkay() {
     if (this.canvas) {
        let json = JSON.stringify(this.canvas.toJSON());
 
@@ -53,7 +53,7 @@ export class BuildingChildPictureEditionPage {
     this.viewCtrl.dismiss(this.picture);
   }
 
-  onCancel() {
+  public onCancel() {
     this.viewCtrl.dismiss(this.picture);
   }
 }

--- a/src/pages/intervention-implantation-plan-sketch/intervention-implantation-plan-sketch.ts
+++ b/src/pages/intervention-implantation-plan-sketch/intervention-implantation-plan-sketch.ts
@@ -3,7 +3,6 @@ import { IonicPage, NavController, NavParams, ViewController } from 'ionic-angul
 import { PictureRepositoryProvider } from './../../providers/repositories/picture-repository';
 import { PictureData } from './../../models/picture-data';
 import { InspectionControllerProvider } from '../../providers/inspection-controller/inspection-controller';
-import { Gesture } from 'ionic-angular/gestures/gesture';
 import { fabric } from 'fabric';
 
 @IonicPage()
@@ -12,7 +11,6 @@ import { fabric } from 'fabric';
   templateUrl: 'intervention-implantation-plan-sketch.html',
 })
 export class InterventionImplantationPlanSketchPage {
-  public labels = {};
   public picture: PictureData;
   public repo: PictureRepositoryProvider;
 
@@ -27,13 +25,7 @@ export class InterventionImplantationPlanSketchPage {
   }
 
   get pictureUri() {
-    if (this.picture.dataUri !== "" || this.picture.dataUri !== null) {
-      const validUri = (this.picture.dataUri.indexOf(';base64,') > 0)
-      ? this.picture.dataUri
-      : 'data:image/jpeg;base64,' + this.picture.dataUri;
-      return validUri;
-    }
-    return '';
+      return this.picture.dataUri;
   }
 
   get sketchJson() {
@@ -52,12 +44,10 @@ export class InterventionImplantationPlanSketchPage {
       this.canvas.absolutePan(new fabric.Point(0, 0));
 
       let imageUri = this.canvas.toDataURL();
-      if (imageUri.indexOf(';base64,') > 0)
-        imageUri = imageUri.substr(imageUri.indexOf(';base64,') + 8);
 
       this.picture = {id: this.picture.id, picture:imageUri, dataUri: imageUri, sketchJson: json};
       this.controller.picture = this.picture;
-      let idPicture = await this.repo.savePicture(this.picture);
+      await this.repo.savePicture(this.picture);
     }
     this.viewCtrl.dismiss();
   }


### PR DESCRIPTION
Should we have only one sketchtool component instead of having 2 pages of sketchtool edition(buildiong child and site plan)