### PR TITLE
#213 grouped question back navigation

### DIFF
--- a/src/pages/inspection-survey-answer/inspection-survey-answer.ts
+++ b/src/pages/inspection-survey-answer/inspection-survey-answer.ts
@@ -322,7 +322,7 @@ export class InspectionSurveyAnswerPage {
             this.inspectionQuestionAnswer.splice(index, 1);
             this.surveyRepo.deleteSurveyAnswers([answerId]).subscribe();
         } else {
-            this.inspectionQuestionAnswer[index] = Object.assign({}, this.currentQuestion);
+            this.inspectionQuestionAnswer[index].childSurveyAnswerList = Object.assign([], this.currentQuestion.childSurveyAnswerList);
         }
         this.currentQuestionAnswerList = this.inspectionQuestionAnswer.filter(answer => answer.idSurveyQuestion == this.currentQuestion.idSurveyQuestion);
         this.getNextQuestionFromAnswer();

--- a/src/pages/inspection-survey-summary/inspection-survey-summary.module.ts
+++ b/src/pages/inspection-survey-summary/inspection-survey-summary.module.ts
@@ -16,4 +16,4 @@ import {TranslateModule} from "@ngx-translate/core";
       TranslateModule.forChild(),
   ],
 })
-export class InspectionQuestionSummaryPageModule {}
+export class InspectionSurveySummaryPageModule {}

--- a/src/pages/inspection-survey-summary/inspection-survey-summary.ts
+++ b/src/pages/inspection-survey-summary/inspection-survey-summary.ts
@@ -8,7 +8,7 @@ import {InspectionSurveyAnswerPage} from '../inspection-survey-answer/inspection
 
 @IonicPage()
 @Component({
-    selector: 'page-inspection-question-summary',
+    selector: 'page-inspection-survey-summary',
     templateUrl: 'inspection-survey-summary.html',
 })
 export class InspectionSurveySummaryPage {

--- a/src/pages/intervention-general/intervention-general.ts
+++ b/src/pages/intervention-general/intervention-general.ts
@@ -178,7 +178,7 @@ export class InterventionGeneralPage implements OnDestroy {
     private validateSurveyNavigation(){
         if (this.controller.inspectionDetail.idSurvey) {
             if (this.controller.inspectionDetail.isSurveyCompleted) {
-                this.navCtrl.push('InspectionQuestionSummaryPage', {idInspection: this.controller.idInspection});
+                this.navCtrl.push('InspectionSurveySummaryPage', {idInspection: this.controller.idInspection});
             }
             else {
                 this.navCtrl.push('InspectionSurveyAnswerPage', {


### PR DESCRIPTION
When deleting group of question and keeping the first parent(when there is only one group).
-> Keeping the last parent and only reseting child answers instead of reserting the group(loose id and answer of the parent)